### PR TITLE
Build.gradle pinning to specific jar versions.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -83,12 +83,12 @@ repositories {
 }
 
 dependencies {
-	compile "com.dell.isg.smi:wsmanlib:1.0.29"
-	compile "com.dell.isg.smi:wsmanclient:+"
+	compile "com.dell.isg.smi:wsmanlib:1.0.40"
+	compile "com.dell.isg.smi:wsmanclient:1.0.25"
     compile 'com.dell.isg.smi:commons-elm:1.0.76'
     compile 'com.dell.isg.smi:commons-utilities:1.0.26'
     compile 'com.dell.isg.smi:commons-model:1.0.80'
-    compile "com.dell.isg.smi:adapter-server:1.0.33"
+    compile "com.dell.isg.smi:adapter-server:1.0.45"
 	compile "org.springframework.boot:spring-boot-starter-web"
 	compile "org.springframework.boot:spring-boot-starter-tomcat"
     compile "org.springframework.boot:spring-boot-starter-actuator"

--- a/src/main/java/com/dell/isg/smi/service/server/inventory/Transformer/TranformerUtil.java
+++ b/src/main/java/com/dell/isg/smi/service/server/inventory/Transformer/TranformerUtil.java
@@ -16,7 +16,7 @@ import com.dell.isg.smi.adapter.server.model.HeadRoom;
 import com.dell.isg.smi.adapter.server.model.PowerMonitoring;
 import com.dell.isg.smi.adapter.server.model.PowerStatistics;
 import com.dell.isg.smi.adapter.server.model.Storage;
-import com.dell.isg.smi.commons.elm.utilities.DateTimeUtils;
+import com.dell.isg.smi.commons.utilities.datetime.DateTimeUtils;
 import com.dell.isg.smi.commons.model.server.inventory.HwBattery;
 import com.dell.isg.smi.commons.model.server.inventory.HwController;
 import com.dell.isg.smi.commons.model.server.inventory.HwCpu;
@@ -169,8 +169,8 @@ public class TranformerUtil {
             hwEnclosure.setEmmCount(NumberUtils.toInt(enclosureView.geteMMCount()));
             hwEnclosure.setFanCount(NumberUtils.toInt(enclosureView.getFanCount()));
             hwEnclosure.setInstanceId(enclosureView.getInstanceID());
-            hwEnclosure.setLastSystemInventoryTime(DateTimeUtils.getIsoDateString(enclosureView.getLastSystemInventoryTime(), TransformerAssemblerConstants.ENCLOSURE_DATE_FORMAT));
-            hwEnclosure.setLastUpdateTime(DateTimeUtils.getIsoDateString(enclosureView.getLastUpdateTime(), TransformerAssemblerConstants.ENCLOSURE_DATE_FORMAT));
+            hwEnclosure.setLastSystemInventoryTime(getIsoDateString(enclosureView.getLastSystemInventoryTime(), TransformerAssemblerConstants.ENCLOSURE_DATE_FORMAT));
+            hwEnclosure.setLastUpdateTime(getIsoDateString(enclosureView.getLastUpdateTime(), TransformerAssemblerConstants.ENCLOSURE_DATE_FORMAT));
             hwEnclosure.setPrimaryStatus(enclosureView.getPrimaryStatus());
             hwEnclosure.setProductName(enclosureView.getProductName());
             hwEnclosure.setPsuCount(NumberUtils.toInt(enclosureView.getpSUCount()));
@@ -355,37 +355,37 @@ public class TranformerUtil {
         PowerStatistics powerStatistics = powerMonitoring.getPowerStatistics();
         if (powerStatistics != null) {
             hwPowerMonitoring.setEnergyConsumption(powerStatistics.getEnergyConsumption());
-            hwPowerMonitoring.setEnergyConsumptionStartDateTime(DateTimeUtils.getIsoDateString(powerStatistics.getEnergyConsumptionStartDateTime(), TransformerAssemblerConstants.POWER_MONITORING_DATE_FORMAT));
-            hwPowerMonitoring.setEnergyConsumptionEndDateTime(DateTimeUtils.getIsoDateString(powerStatistics.getEnergyConsumptionEndDateTime(), TransformerAssemblerConstants.POWER_MONITORING_DATE_FORMAT));
+            hwPowerMonitoring.setEnergyConsumptionStartDateTime(getIsoDateString(powerStatistics.getEnergyConsumptionStartDateTime(), TransformerAssemblerConstants.POWER_MONITORING_DATE_FORMAT));
+            hwPowerMonitoring.setEnergyConsumptionEndDateTime(getIsoDateString(powerStatistics.getEnergyConsumptionEndDateTime(), TransformerAssemblerConstants.POWER_MONITORING_DATE_FORMAT));
 
             hwPowerMonitoring.setSystemPeakPower(powerStatistics.getSystemPeakPower());
-            hwPowerMonitoring.setSystemPeakPowerStartDateTime(DateTimeUtils.getIsoDateString(powerStatistics.getSystemPeakPowerStartDateTime(), TransformerAssemblerConstants.POWER_MONITORING_DATE_FORMAT));
-            hwPowerMonitoring.setSystemPeakPowerEndDateTime(DateTimeUtils.getIsoDateString(powerStatistics.getSystemPeakPowerEndDateTime(), TransformerAssemblerConstants.POWER_MONITORING_DATE_FORMAT));
+            hwPowerMonitoring.setSystemPeakPowerStartDateTime(getIsoDateString(powerStatistics.getSystemPeakPowerStartDateTime(), TransformerAssemblerConstants.POWER_MONITORING_DATE_FORMAT));
+            hwPowerMonitoring.setSystemPeakPowerEndDateTime(getIsoDateString(powerStatistics.getSystemPeakPowerEndDateTime(), TransformerAssemblerConstants.POWER_MONITORING_DATE_FORMAT));
 
             hwPowerMonitoring.setSystemPeakAmps(powerStatistics.getSystemPeakAmps());
-            hwPowerMonitoring.setPeakAmpsStartDateTime(DateTimeUtils.getIsoDateString(powerStatistics.getPeakAmpsStartDateTime(), TransformerAssemblerConstants.POWER_MONITORING_DATE_FORMAT));
-            hwPowerMonitoring.setPeakAmpsEndDateTime(DateTimeUtils.getIsoDateString(powerStatistics.getPeakAmpsEndDateTime(), TransformerAssemblerConstants.POWER_MONITORING_DATE_FORMAT));
+            hwPowerMonitoring.setPeakAmpsStartDateTime(getIsoDateString(powerStatistics.getPeakAmpsStartDateTime(), TransformerAssemblerConstants.POWER_MONITORING_DATE_FORMAT));
+            hwPowerMonitoring.setPeakAmpsEndDateTime(getIsoDateString(powerStatistics.getPeakAmpsEndDateTime(), TransformerAssemblerConstants.POWER_MONITORING_DATE_FORMAT));
 
             hwPowerMonitoring.setLastHourPeakAverage(powerStatistics.getLastHourPeakAverage());
-            hwPowerMonitoring.setLastHourPeakTime(DateTimeUtils.getIsoDateString(powerStatistics.getLastHourPeakTime(), TransformerAssemblerConstants.POWER_MONITORING_DATE_FORMAT));
+            hwPowerMonitoring.setLastHourPeakTime(getIsoDateString(powerStatistics.getLastHourPeakTime(), TransformerAssemblerConstants.POWER_MONITORING_DATE_FORMAT));
             hwPowerMonitoring.setLastHourPeakMax(powerStatistics.getLastHourPeakMax());
-            hwPowerMonitoring.setLastHourPeakMaxTime(DateTimeUtils.getIsoDateString(powerStatistics.getLastHourPeakMaxTime(), TransformerAssemblerConstants.POWER_MONITORING_DATE_FORMAT));
+            hwPowerMonitoring.setLastHourPeakMaxTime(getIsoDateString(powerStatistics.getLastHourPeakMaxTime(), TransformerAssemblerConstants.POWER_MONITORING_DATE_FORMAT));
             hwPowerMonitoring.setLastHourPeakMin(powerStatistics.getLastHourPeakMin());
-            hwPowerMonitoring.setLastHourPeakMinTime(DateTimeUtils.getIsoDateString(powerStatistics.getLastHourPeakMinTime(), TransformerAssemblerConstants.POWER_MONITORING_DATE_FORMAT));
+            hwPowerMonitoring.setLastHourPeakMinTime(getIsoDateString(powerStatistics.getLastHourPeakMinTime(), TransformerAssemblerConstants.POWER_MONITORING_DATE_FORMAT));
 
             hwPowerMonitoring.setLastDayPeakAverage(powerStatistics.getLastDayPeakAverage());
-            hwPowerMonitoring.setLastDayPeakTime(DateTimeUtils.getIsoDateString(powerStatistics.getLastDayPeakTime(), TransformerAssemblerConstants.POWER_MONITORING_DATE_FORMAT));
+            hwPowerMonitoring.setLastDayPeakTime(getIsoDateString(powerStatistics.getLastDayPeakTime(), TransformerAssemblerConstants.POWER_MONITORING_DATE_FORMAT));
             hwPowerMonitoring.setLastDayPeakMax(powerStatistics.getLastDayPeakMax());
-            hwPowerMonitoring.setLastDayPeakMaxTime(DateTimeUtils.getIsoDateString(powerStatistics.getLastDayPeakMaxTime(), TransformerAssemblerConstants.POWER_MONITORING_DATE_FORMAT));
+            hwPowerMonitoring.setLastDayPeakMaxTime(getIsoDateString(powerStatistics.getLastDayPeakMaxTime(), TransformerAssemblerConstants.POWER_MONITORING_DATE_FORMAT));
             hwPowerMonitoring.setLastDayPeakMin(powerStatistics.getLastDayPeakMin());
-            hwPowerMonitoring.setLastDayPeakMinTime(DateTimeUtils.getIsoDateString(powerStatistics.getLastDayPeakMinTime(), TransformerAssemblerConstants.POWER_MONITORING_DATE_FORMAT));
+            hwPowerMonitoring.setLastDayPeakMinTime(getIsoDateString(powerStatistics.getLastDayPeakMinTime(), TransformerAssemblerConstants.POWER_MONITORING_DATE_FORMAT));
 
             hwPowerMonitoring.setLastWeekPeakAverage(powerStatistics.getLastWeekPeakAverage());
-            hwPowerMonitoring.setLastWeekPeakTime(DateTimeUtils.getIsoDateString(powerStatistics.getLastWeekPeakTime(), TransformerAssemblerConstants.POWER_MONITORING_DATE_FORMAT));
+            hwPowerMonitoring.setLastWeekPeakTime(getIsoDateString(powerStatistics.getLastWeekPeakTime(), TransformerAssemblerConstants.POWER_MONITORING_DATE_FORMAT));
             hwPowerMonitoring.setLastWeekPeakMax(powerStatistics.getLastWeekPeakMax());
-            hwPowerMonitoring.setLastWeekPeakMaxTime(DateTimeUtils.getIsoDateString(powerStatistics.getLastWeekPeakMaxTime(), TransformerAssemblerConstants.POWER_MONITORING_DATE_FORMAT));
+            hwPowerMonitoring.setLastWeekPeakMaxTime(getIsoDateString(powerStatistics.getLastWeekPeakMaxTime(), TransformerAssemblerConstants.POWER_MONITORING_DATE_FORMAT));
             hwPowerMonitoring.setLastWeekPeakMin(powerStatistics.getLastWeekPeakMin());
-            hwPowerMonitoring.setLastWeekPeakMinTime(DateTimeUtils.getIsoDateString(powerStatistics.getLastWeekPeakMinTime(), TransformerAssemblerConstants.POWER_MONITORING_DATE_FORMAT));
+            hwPowerMonitoring.setLastWeekPeakMinTime(getIsoDateString(powerStatistics.getLastWeekPeakMinTime(), TransformerAssemblerConstants.POWER_MONITORING_DATE_FORMAT));
         }
 
         HeadRoom headRoom = powerMonitoring.getHeadRoom();
@@ -396,6 +396,29 @@ public class TranformerUtil {
         return hwPowerMonitoring;
     }
 
+    private static String getIsoDateString(String dateString, String dateFormat) {
+        try{
+            return DateTimeUtils.getIsoDateString(dateString,  dateFormat );
+        }
+        catch(Exception e)
+        {
+            logger.debug("failed to parse string");
+            return "";
+        }
+    }
+    
+    
+    private static String getIsoDateString(String utcDateString, String[] datePatterns){
+        try{
+            return DateTimeUtils.getIsoDateString(utcDateString,  datePatterns );
+        }
+        catch(Exception e)
+        {
+            logger.debug("failed to parse string array");
+            return "";
+        }
+    }
+    
 
     private static List<HwSDCard> transformSdCards(List<VFlashView> vflashViews) {
         List<HwSDCard> hwSdCardList = new ArrayList<HwSDCard>();
@@ -650,7 +673,7 @@ public class TranformerUtil {
         hwSystem.setAssetTag(system.getAssetTag() != null ? system.getAssetTag().getValue() : null);
         hwSystem.setBatteryRollupStatus(system.getBatteryRollupStatus() != null ? String.valueOf(system.getBatteryRollupStatus().getValue()) : null);
         if (system.getBiosReleaseDate() != null) {
-            hwSystem.setBiosReleaseDate(DateTimeUtils.getIsoDateString(system.getBiosReleaseDate().getValue(), TransformerAssemblerConstants.DATE_PATTERNS));
+            hwSystem.setBiosReleaseDate(getIsoDateString(system.getBiosReleaseDate().getValue(), TransformerAssemblerConstants.DATE_PATTERNS));
         }
         hwSystem.setBiosVersionString(system.getBiosVersionString() != null ? system.getBiosVersionString().getValue() : null);
         hwSystem.setBoardPartNumber(system.getBoardPartNumber() != null ? system.getBoardPartNumber().getValue() : null);


### PR DESCRIPTION
TransformerUtil, adding private methods to eat null and parse exceptions for string conversion.  The method in the utility no longer eats it, so it is up to the higher layer to do so.